### PR TITLE
Libreoffice 'Formmatting Citation' issue.

### DIFF
--- a/external/zoteroLib.vb
+++ b/external/zoteroLib.vb
@@ -690,7 +690,7 @@ Sub deleteInvisibleCharacter(oRange)
     ' separate the reference mark from the user's text
     Dim oDupRange
 
-    oDupRange = thisComponent.currentController.viewCursor.Text.createTextCursorByRange(oRange)
+    oDupRange = oRange.Text.createTextCursorByRange(oRange)
 
     oDupRange.collapseToEnd
     oDupRange.goRight(1, True)

--- a/src/mendeleyLib.vb
+++ b/src/mendeleyLib.vb
@@ -1013,7 +1013,6 @@ Function ChangeMarkFormat(oMark, fieldType as String)
         deleteInvisibleCharacter(oRange)
     End If
     
-    oRange.String = citationText
     oRange.text.insertTextContent(oRange, oNewMark, true)
     oNewMark = fnRenameMark(oNewMark, citationCode)
    


### PR DESCRIPTION
Deleted this line:
oRange.String = citationText
it was deleting the format on Export to MS Word Office (e.g. if some citations had italic/bold).

zoteroLib.vb change to avoid a LibreOffice Basic error.

MD-22146