### PR TITLE
Exports as Word 2007-2013 compatible explicitly and with the correct …

### DIFF
--- a/src/mendeleyMain.vb
+++ b/src/mendeleyMain.vb
@@ -1069,8 +1069,13 @@ Sub exportCompatibleMSWord()
 
     oFileDialog.Initialize(sFilePickerArgs())
     oFileDialog.setTitle("Save To...")
-    oFileDialog.appendFilter("Microsoft Word (*.doc)", "*.doc")
+
+    Dim filterName As String
+    filterName = "Microsoft Word 2007-2013 XML (.docx)"
+
+    oFileDialog.appendFilter(filterName, "*.docx")
     oFileDialog.appendFilter("All Files", "*.*")
+    oFileDialog.setCurrentFilter(FilterName)
 
     dim sFileUrl
     if oFileDialog.execute() then
@@ -1119,6 +1124,7 @@ Sub exportAsBookmarks(fileUrl)
 
         dim exportProperties(1) as new com.sun.star.beans.PropertyValue
         exportProperties(0).Name = "FilterName"
+        exportProperties(0).Value = "MS Word 2007 XML"
         ThisComponent.storeToUrl(fileUrl, exportProperties())
     End If
 End Sub


### PR DESCRIPTION
…file extension.

Before this commit it was hapening implicitly, it's explicit thanks to:
exportProperties(0).Value = "MS Word 2007 XML"

Also, the "Save To" dialogue was using ".doc" instead of ".docx" which
was confusing as the extension didn't match the contents of the file.

MD-22829